### PR TITLE
Update fast-syntax-highlighting repo

### DIFF
--- a/.local/bin/update-zsh-plugins
+++ b/.local/bin/update-zsh-plugins
@@ -20,5 +20,5 @@ function clone_or_pull {
     fi
 }
 
-clone_or_pull "zdharma/fast-syntax-highlighting"
+clone_or_pull "zdharma-continuum/fast-syntax-highlighting"
 clone_or_pull "zsh-users/zsh-autosuggestions"


### PR DESCRIPTION
https://github.com/zdharma/fast-syntax-highlighting no longer exists.

Looks like https://github.com/zdharma-continuum, which does exist, does the same thing.