### PR TITLE
Pass all `GIT_ARGS` to git diff not just the first

### DIFF
--- a/.local/bin/gd
+++ b/.local/bin/gd
@@ -26,7 +26,6 @@ done
 
 GIT_ARGS+=("--color=always")
 printf -v GIT_ARGS_STRING "%q " "${GIT_ARGS[@]}"
-GIT_ARGS_STRING="${GIT_ARGS_STRING%" "}"
 
 git diff "${GIT_ARGS[@]}" --name-only |
   fzf \


### PR DESCRIPTION
`${GIT_ARGS:-}` only substitutes the first element of the array, not all elements.

`"${GIT_ARGS[@]}"` will substitute all elements of the array, with each element as its own word.

For the command string that is passed to `fzf --preview`, `printf -v GIT_ARGS_STRING "%q " "${GIT_ARGS[@]}"` is used. This concatenates the array into a space-separated string. In the event that one of the array elements itself contains a space, this command will avoid it being split into multiple words when it is eventually passed back to the shell for evaluation, by using `%q` to escape spaces and other special characters.

This fixes a regression that appears to have been introduced by commit [bdf33d8](https://github.com/nickjj/dotfiles/commit/bdf33d8). `${@:-}` and `${*:-}` used to be used, which would expand all positional arguments.